### PR TITLE
feat: enable informer re-sync.

### DIFF
--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
+	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -186,7 +187,9 @@ func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) error {
 	}
 
 	log.Log(log.ShimClient).Info("registering event handler", zap.Stringer("type", handlers.Type))
-	if err := s.addEventHandlers(handlers.Type, h, 0); err != nil {
+
+	resyncPeriod := utils.GetInformerResyncPeriod()
+	if err := s.addEventHandlers(handlers.Type, h, resyncPeriod); err != nil {
 		return errors.Join(errors.New("failed to initialize event handlers: "), err)
 	}
 	return nil

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -56,6 +57,24 @@ func SetPluginMode(value bool) {
 
 func IsPluginMode() bool {
 	return pluginMode
+}
+
+// GetInformerResyncPeriod returns the resync period for informers from environment variable.
+func GetInformerResyncPeriod() time.Duration {
+	if envVal, ok := os.LookupEnv(conf.EnvInformerResyncPeriod); ok && envVal != "" {
+		if duration, err := time.ParseDuration(envVal); err == nil && duration >= 0 {
+			if duration > 0 {
+				log.Log(log.ShimUtils).Info("Informer resync enabled",
+					zap.String("resyncPeriod", duration.String()),
+					zap.String("envVar", conf.EnvInformerResyncPeriod))
+				return duration
+			}
+			return 0
+		}
+		log.Log(log.ShimUtils).Warn("Invalid YUNIKORN_INFORMER_RESYNC_PERIOD value, using default (disabled)",
+			zap.String("value", envVal))
+	}
+	return 0 // Default: disabled
 }
 
 func Convert2Pod(obj interface{}) (*v1.Pod, error) {

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1500,5 +1501,62 @@ func TestWaitForCondition(t *testing.T) {
 		} else {
 			assert.Equal(t, get.Error(), test.output.Error())
 		}
+	}
+}
+
+func TestGetInformerResyncPeriod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+		setEnv   bool
+	}{
+		{
+			name:     "environment variable not set",
+			envValue: "",
+			expected: 0,
+			setEnv:   false,
+		},
+		{
+			name:     "environment variable set to empty string",
+			envValue: "",
+			expected: 0,
+			setEnv:   true,
+		},
+		{
+			name:     "environment variable set to valid positive duration",
+			envValue: "30s",
+			expected: 30 * time.Second,
+			setEnv:   true,
+		},
+		{
+			name:     "environment variable set to 0",
+			envValue: "0",
+			expected: 0,
+			setEnv:   true,
+		},
+		{
+			name:     "environment variable set to invalid value",
+			envValue: "invalid",
+			expected: 0,
+			setEnv:   true,
+		},
+		{
+			name:     "environment variable set to negative duration",
+			envValue: "-10s",
+			expected: 0,
+			setEnv:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				os.Setenv(conf.EnvInformerResyncPeriod, tc.envValue)
+			}
+
+			result := GetInformerResyncPeriod()
+			assert.Equal(t, result, tc.expected)
+		})
 	}
 }

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -47,9 +47,10 @@ type SchedulerConfFactory = func() *SchedulerConf
 
 const (
 	// env vars
-	EnvHome       = "HOME"
-	EnvKubeConfig = "KUBECONFIG"
-	EnvNamespace  = "NAMESPACE"
+	EnvHome                 = "HOME"
+	EnvKubeConfig           = "KUBECONFIG"
+	EnvNamespace            = "NAMESPACE"
+	EnvInformerResyncPeriod = "YUNIKORN_INFORMER_RESYNC_PERIOD"
 
 	// prefixes
 	PrefixService             = "service."

--- a/pkg/plugin/scheduler_plugin.go
+++ b/pkg/plugin/scheduler_plugin.go
@@ -287,7 +287,8 @@ func NewSchedulerPlugin(_ context.Context, _ runtime.Object, handle framework.Ha
 	}
 
 	// we need our own informer factory here because the informers we get from the framework handle aren't yet initialized
-	informerFactory := informers.NewSharedInformerFactory(handle.ClientSet(), 0)
+	resyncPeriod := utils.GetInformerResyncPeriod()
+	informerFactory := informers.NewSharedInformerFactory(handle.ClientSet(), resyncPeriod)
 	ss := shim.NewShimSchedulerForPlugin(serviceContext.RMProxy, informerFactory, conf.GetSchedulerConf(), configMaps)
 	if err := ss.Run(); err != nil {
 		log.Log(log.ShimSchedulerPlugin).Fatal("Unable to start scheduler", zap.Error(err))

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -61,8 +61,8 @@ var (
 func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, bootstrapConfigMaps []*v1.ConfigMap) *KubernetesShim {
 	kubeClient := client.NewKubeClient(configs.KubeConfig)
 
-	// we have disabled re-sync to keep ourselves up-to-date
-	informerFactory := informers.NewSharedInformerFactory(kubeClient.GetClientSet(), 0)
+	resyncPeriod := utils.GetInformerResyncPeriod()
+	informerFactory := informers.NewSharedInformerFactory(kubeClient.GetClientSet(), resyncPeriod)
 
 	apiFactory := client.NewAPIFactory(scheduler, informerFactory, configs, false)
 	context := cache.NewContextWithBootstrapConfigMaps(apiFactory, bootstrapConfigMaps)


### PR DESCRIPTION
related to https://github.com/G-Research/gr-oss/issues/1158

Added support for a configurable informer resync period, controlled via the environment variable `YUNIKORN_INFORMER_RESYNC_PERIOD`.