### PR TITLE
Retry on pod and volume binding using exponential backoff

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -371,11 +371,23 @@ func (task *Task) postTaskAllocated() {
 				"Successfully assigned %s to node %s", task.alias, task.nodeName)
 
 			// before binding pod to node, first bind volumes to pod
+			const maxRetries = 5
+			const baseDelay = 100 * time.Millisecond
 			log.Log(log.ShimCacheTask).Debug("bind pod volumes",
 				zap.String("podName", task.pod.Name),
 				zap.String("podUID", string(task.pod.UID)))
-			if err := task.context.bindPodVolumes(task.pod); err != nil {
-				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed", zap.String("taskID", task.taskID), zap.Error(err))
+
+			if err := RetryWithExponentialBackoff(
+				maxRetries,
+				baseDelay,
+				func() error {
+					return task.context.bindPodVolumes(task.pod)
+				},
+				"bindPodVolumes",
+				task.taskID,
+				log.Log(log.ShimCacheTask),
+			); err != nil {
+				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed after retries", zap.String("taskID", task.taskID), zap.Error(err))
 				task.failWithEvent(fmt.Sprintf("bind volumes to pod failed, name: %s, %s", task.alias, err.Error()), "PodVolumesBindFailure")
 				return
 			}
@@ -384,8 +396,17 @@ func (task *Task) postTaskAllocated() {
 				zap.String("podName", task.pod.Name),
 				zap.String("podUID", string(task.pod.UID)))
 
-			if err := task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, task.nodeName); err != nil {
-				log.Log(log.ShimCacheTask).Error("bind pod to node failed", zap.String("taskID", task.taskID), zap.Error(err))
+			if err := RetryWithExponentialBackoff(
+				maxRetries,
+				baseDelay,
+				func() error {
+					return task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, task.nodeName)
+				},
+				"bindPod",
+				task.taskID,
+				log.Log(log.ShimCacheTask),
+			); err != nil {
+				log.Log(log.ShimCacheTask).Error("bind pod to node failed after retries", zap.String("taskID", task.taskID), zap.Error(err))
 				task.failWithEvent(fmt.Sprintf("bind pod to node failed, name: %s, %s", task.alias, err.Error()), "PodBindFailure")
 				return
 			}

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -371,7 +372,7 @@ func (task *Task) postTaskAllocated() {
 				"Successfully assigned %s to node %s", task.alias, task.nodeName)
 
 			// before binding pod to node, first bind volumes to pod
-			const maxRetries = 5
+			maxRetries := schedulerconf.GetSchedulerConf().GetPodBindMaxRetries()
 			const baseDelay = 100 * time.Millisecond
 			log.Log(log.ShimCacheTask).Debug("bind pod volumes",
 				zap.String("podName", task.pod.Name),

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -83,7 +83,7 @@ func RetryWithExponentialBackoff(
 				zap.Duration("backoff", delay),
 				zap.Error(lastErr))
 			time.Sleep(delay)
-			delay = delay * 2 // exponential backoff
+			delay *= 2 // exponential backoff
 		}
 
 		lastErr = operation()

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -65,6 +65,7 @@ func GetTaskGroupsFromAnnotation(pod *v1.Pod) ([]TaskGroup, error) {
 
 // RetryWithExponentialBackoff retries a function with exponential backoff.
 // It performs up to maxRetries attempts with exponential backoff starting at baseDelay.
+// If maxRetries is negative, it will retry indefinitely until the operation succeeds.
 // Returns the last error if all retries fail, or nil on success.
 func RetryWithExponentialBackoff(
 	maxRetries int,
@@ -72,8 +73,9 @@ func RetryWithExponentialBackoff(
 	operation func() error, operationName string, taskID string, logger *zap.Logger) error {
 	var lastErr error
 	delay := baseDelay
+	infiniteRetry := maxRetries < 0
 
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := 0; infiniteRetry || attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			logger.Warn("retrying operation",
 				zap.String("operation", operationName),
@@ -98,10 +100,14 @@ func RetryWithExponentialBackoff(
 		}
 	}
 
-	logger.Error("operation failed after all retries",
-		zap.String("operation", operationName),
-		zap.String("taskID", taskID),
-		zap.Int("totalAttempts", maxRetries),
-		zap.Error(lastErr))
+	if !infiniteRetry {
+		logger.Error("operation failed after all retries",
+			zap.String("operation", operationName),
+			zap.String("taskID", taskID),
+			zap.Int("totalAttempts", maxRetries),
+			zap.Error(lastErr))
+		return lastErr
+	}
+	// This should never be reached for infinite retry, but included anyway
 	return lastErr
 }

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -21,7 +21,9 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
@@ -59,4 +61,47 @@ func GetTaskGroupsFromAnnotation(pod *v1.Pod) ([]TaskGroup, error) {
 		}
 	}
 	return taskGroups, nil
+}
+
+// RetryWithExponentialBackoff retries a function with exponential backoff.
+// It performs up to maxRetries attempts with exponential backoff starting at baseDelay.
+// Returns the last error if all retries fail, or nil on success.
+func RetryWithExponentialBackoff(
+	maxRetries int,
+	baseDelay time.Duration,
+	operation func() error, operationName string, taskID string, logger *zap.Logger) error {
+	var lastErr error
+	delay := baseDelay
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			logger.Warn("retrying operation",
+				zap.String("operation", operationName),
+				zap.String("taskID", taskID),
+				zap.Int("attempt", attempt+1),
+				zap.Int("maxRetries", maxRetries),
+				zap.Duration("backoff", delay),
+				zap.Error(lastErr))
+			time.Sleep(delay)
+			delay = delay * 2 // exponential backoff
+		}
+
+		lastErr = operation()
+		if lastErr == nil {
+			if attempt > 0 {
+				logger.Info("operation succeeded after retry",
+					zap.String("operation", operationName),
+					zap.String("taskID", taskID),
+					zap.Int("attempt", attempt+1))
+			}
+			return nil
+		}
+	}
+
+	logger.Error("operation failed after all retries",
+		zap.String("operation", operationName),
+		zap.String("taskID", taskID),
+		zap.Int("totalAttempts", maxRetries),
+		zap.Error(lastErr))
+	return lastErr
 }

--- a/pkg/cache/utils_test.go
+++ b/pkg/cache/utils_test.go
@@ -19,8 +19,11 @@
 package cache
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	"go.uber.org/zap"
 	"gotest.tools/v3/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -216,4 +219,61 @@ func TestGetTaskGroupFromAnnotation(t *testing.T) {
 	assert.Equal(t, taskGroups2[0].MinMember, int32(3))
 	assert.Equal(t, taskGroups2[0].MinResource["cpu"], resource.MustParse("2"))
 	assert.Equal(t, taskGroups2[0].MinResource["memory"], resource.MustParse("1Gi"))
+}
+
+func TestRetryWithExponentialBackoff(t *testing.T) {
+	logger := zap.NewNop()
+	baseDelay := 10 * time.Millisecond
+
+	tests := []struct {
+		name             string
+		maxRetries       int
+		successOnAttempt int // =0 always fail, >0 succeed on this attempt
+		expectedErr      error
+		expectedAttempt  int
+	}{
+		{
+			name:             "success on first attempt",
+			maxRetries:       3,
+			successOnAttempt: 1,
+			expectedErr:      nil,
+			expectedAttempt:  1,
+		},
+		{
+			name:             "success after retries",
+			maxRetries:       5,
+			successOnAttempt: 3,
+			expectedErr:      nil,
+			expectedAttempt:  3,
+		},
+		{
+			name:             "failure after all retries",
+			maxRetries:       3,
+			successOnAttempt: 0,
+			expectedErr:      errors.New("persistent error"),
+			expectedAttempt:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attemptCount := 0
+			operation := func() error {
+				attemptCount++
+				if tt.successOnAttempt > 0 && attemptCount == tt.successOnAttempt {
+					return nil
+				}
+				return errors.New("persistent error")
+			}
+
+			err := RetryWithExponentialBackoff(tt.maxRetries, baseDelay, operation, "test-operation", "test-task", logger)
+
+			if tt.expectedErr == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, tt.expectedErr.Error())
+			}
+			assert.Equal(t, attemptCount, tt.expectedAttempt)
+		})
+	}
 }

--- a/pkg/cache/utils_test.go
+++ b/pkg/cache/utils_test.go
@@ -253,6 +253,13 @@ func TestRetryWithExponentialBackoff(t *testing.T) {
 			expectedErr:      errors.New("persistent error"),
 			expectedAttempt:  3,
 		},
+		{
+			name:             "infinite retry succeeds",
+			maxRetries:       -1,
+			successOnAttempt: 5,
+			expectedErr:      nil,
+			expectedAttempt:  5,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -68,6 +68,7 @@ const (
 	CMSvcEnableConfigHotRefresh       = PrefixService + "enableConfigHotRefresh"
 	CMSvcPlaceholderImage             = PrefixService + "placeholderImage"
 	CMSvcNodeInstanceTypeNodeLabelKey = PrefixService + "nodeInstanceTypeNodeLabelKey"
+	CMSvcPodBindMaxRetries            = PrefixService + "podBindMaxRetries"
 
 	// kubernetes
 	CMKubeQPS   = PrefixKubernetes + "qps"
@@ -91,6 +92,7 @@ const (
 	DefaultKubeQPS                         = 1000
 	DefaultKubeBurst                       = 1000
 	DefaultAMFilteringGenerateUniqueAppIds = false
+	DefaultPodBindMaxRetries               = 5
 )
 
 var (
@@ -129,6 +131,7 @@ type SchedulerConf struct {
 	InstanceTypeNodeLabelKey string        `json:"instanceTypeNodeLabelKey"`
 	Namespace                string        `json:"namespace"`
 	GenerateUniqueAppIds     bool          `json:"generateUniqueAppIds"`
+	PodBindMaxRetries        int           `json:"podBindMaxRetries"`
 
 	locking.RWMutex
 }
@@ -157,6 +160,7 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		InstanceTypeNodeLabelKey: conf.InstanceTypeNodeLabelKey,
 		Namespace:                conf.Namespace,
 		GenerateUniqueAppIds:     conf.GenerateUniqueAppIds,
+		PodBindMaxRetries:        conf.PodBindMaxRetries,
 	}
 }
 
@@ -287,6 +291,12 @@ func (conf *SchedulerConf) GetKubeConfigPath() string {
 	return conf.KubeConfig
 }
 
+func (conf *SchedulerConf) GetPodBindMaxRetries() int {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.PodBindMaxRetries
+}
+
 func GetSchedulerNamespace() string {
 	if value, ok := os.LookupEnv(EnvNamespace); ok {
 		return value
@@ -332,6 +342,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		PlaceHolderImage:         constants.PlaceholderContainerImage,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
 		GenerateUniqueAppIds:     DefaultAMFilteringGenerateUniqueAppIds,
+		PodBindMaxRetries:        DefaultPodBindMaxRetries,
 	}
 }
 
@@ -356,6 +367,7 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	parser.boolVar(&conf.EnableConfigHotRefresh, CMSvcEnableConfigHotRefresh)
 	parser.stringVar(&conf.PlaceHolderImage, CMSvcPlaceholderImage)
 	parser.stringVar(&conf.InstanceTypeNodeLabelKey, CMSvcNodeInstanceTypeNodeLabelKey)
+	parser.intVar(&conf.PodBindMaxRetries, CMSvcPodBindMaxRetries)
 
 	// kubernetes
 	parser.intVar(&conf.KubeQPS, CMKubeQPS)

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -75,6 +75,7 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
 	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
+	assert.Equal(t, conf.PodBindMaxRetries, DefaultPodBindMaxRetries)
 }
 
 func TestDecompress(t *testing.T) {
@@ -124,6 +125,7 @@ func TestParseConfigMap(t *testing.T) {
 		{CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false},
 		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image"},
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type"},
+		{CMSvcPodBindMaxRetries, "PodBindMaxRetries", 10},
 		{CMKubeQPS, "KubeQPS", 2345},
 		{CMKubeBurst, "KubeBurst", 3456},
 	}
@@ -155,6 +157,7 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
 		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image", false},
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type", false},
+		{CMSvcPodBindMaxRetries, "PodBindMaxRetries", 10, true},
 		{CMKubeQPS, "KubeQPS", 2345, false},
 		{CMKubeBurst, "KubeBurst", 3456, false},
 	}
@@ -211,6 +214,73 @@ func TestParseConfigMapWithInvalidDuration(t *testing.T) {
 	assert.Assert(t, conf == nil, "conf exists")
 	assert.Equal(t, 1, len(errs), "wrong error count")
 	assert.ErrorContains(t, errs[0], "invalid duration", "wrong error type")
+}
+
+func TestPodBindMaxRetries(t *testing.T) {
+	tests := []struct {
+		name           string
+		configMapValue string
+		expectedValue  int
+		useConfigMap   bool
+		expectError    bool
+	}{
+		{
+			name:           "default value",
+			configMapValue: "",
+			expectedValue:  DefaultPodBindMaxRetries,
+			useConfigMap:   false,
+			expectError:    false,
+		},
+		{
+			name:           "positive value via ConfigMap",
+			configMapValue: "15",
+			expectedValue:  15,
+			useConfigMap:   true,
+			expectError:    false,
+		},
+		{
+			name:           "negative value for infinite retry",
+			configMapValue: "-1",
+			expectedValue:  -1,
+			useConfigMap:   true,
+			expectError:    false,
+		},
+		{
+			name:           "zero value",
+			configMapValue: "0",
+			expectedValue:  0,
+			useConfigMap:   true,
+			expectError:    false,
+		},
+		{
+			name:           "invalid value",
+			configMapValue: "invalid",
+			useConfigMap:   true,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.useConfigMap {
+				prev := CreateDefaultConfig()
+				conf, errs := parseConfig(map[string]string{CMSvcPodBindMaxRetries: tt.configMapValue}, prev)
+				if tt.expectError {
+					assert.Assert(t, conf == nil, "conf should be nil on error")
+					assert.Assert(t, errs != nil, "errs should not be nil on error")
+				} else {
+					assert.Assert(t, conf != nil, "conf was nil")
+					assert.Assert(t, errs == nil, errs)
+					assert.Equal(t, tt.expectedValue, conf.PodBindMaxRetries)
+					assert.Equal(t, tt.expectedValue, conf.GetPodBindMaxRetries())
+				}
+			} else {
+				// Test default value
+				conf := GetSchedulerConf()
+				assert.Equal(t, tt.expectedValue, conf.GetPodBindMaxRetries())
+			}
+		})
+	}
 }
 
 // get a configuration value by field name


### PR DESCRIPTION
Fixes https://github.com/G-Research/gr-oss/issues/1162

Tested using `make test` and `make lint`, and also performed manual testing on a Kind cluster.

### Configuration
Use `service.podBindMaxRetries: "10"` to configure the maxRetries. To retry infinitely, set **podBindMaxRetries** to a **negative** value.

If not set, defaults to 5 retries

Example config
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: yunikorn-configs
  namespace: yunikorn
data:
  service.podBindMaxRetries: "10"
  queues.yaml: |-
    partitions:
      - name: default
        preemption:
          enabled: true
 ...
```

